### PR TITLE
IS-2: Region divider should only span grid rows and column headers

### DIFF
--- a/overrides/grid/HeaderContainer.js
+++ b/overrides/grid/HeaderContainer.js
@@ -1,0 +1,42 @@
+/**
+ * Updated to sort column(s) before adding them to the grid item list.
+ * This ensures that columns are grouped together by region before they
+ * are added to the grid.
+ */
+Ext.define('cssLockedGrid.grid.HeaderContainer', {
+    override: 'Ext.grid.HeaderContainer',
+
+    // If (re)configuring - sort items by region first
+    add: function(items) {
+
+        if (this.isCssLockedGrid && this.items.length === 0) {
+            this.sortByRegion(items);
+        }
+
+        return this.callParent([ items ]);
+    },
+
+    privates: {
+        sortByRegion: function(items) {
+            var me = this,
+                regions = me.getGrid().getRegions();
+
+            if (items) {
+                Ext.Array.sort(items, function(lhs, rhs) {
+                    return regions[me.getLockedRegion(lhs)].weight - regions[me.getLockedRegion(rhs)].weight;
+                });
+            }
+        },
+
+        getLockedRegion: function(item) {
+            switch (item.locked) {
+                case (true || 'left') :
+                    return 'left';
+                case 'right':
+                    return 'right';
+                default:
+                    return 'center'
+            }
+        }
+    }
+})

--- a/overrides/grid/HeaderDropZone.js
+++ b/overrides/grid/HeaderDropZone.js
@@ -65,7 +65,7 @@ Ext.define('cssLockedGrid.grid.HeaderDropZone', {
         }
 
         // NEW - Update lock info
-        if (me.view.isLockedGrid) {
+        if (me.view.isCssLockedGrid) {
             sourceCmp.setLocked(targetCmp.getLocked())
         }
 

--- a/overrides/grid/NavigationModel.js
+++ b/overrides/grid/NavigationModel.js
@@ -31,7 +31,7 @@ Ext.define('cssLockedGrid.grid.NavigationModel', {
         }
 
         // >>>>> NEW CODE
-        if (view.isLockedGrid && location && !location.column.getLocked() && view.hasLockedRegions()) {
+        if (view.isCssLockedGrid && location && !location.column.getLocked() && view.hasLockedRegions()) {
             Ext.apply(options, {
                 adjustForCenterRegion: true,
                 location: location

--- a/overrides/grid/column/Column.js
+++ b/overrides/grid/column/Column.js
@@ -65,6 +65,8 @@ Ext.define('cssLockedGrid.grid.column.Column', {
             colIndex = columns.indexOf(me),
             method, cls, pos;
 
+        me.locked = newVal;
+
         me.updateLockedCls(newVal);
 
         if (me.isRendered()) {

--- a/overrides/grid/selection/SelectionExtender.js
+++ b/overrides/grid/selection/SelectionExtender.js
@@ -37,7 +37,7 @@ Ext.define('cssLockedGrid.grid.selection.SelectionExtender', {
     isHandleWithinView: function (view) {
         var me = this,
             // CHANGE
-            viewBox = view.isLockedGrid ? view.getCenterRegionBox() : view.el.getBox(),
+            viewBox = view.isCssLockedGrid ? view.getCenterRegionBox() : view.el.getBox(),
             handleBox = me.handle.getBox(),
             withinX;
 

--- a/overrides/scroll/indicator/Bar.js
+++ b/overrides/scroll/indicator/Bar.js
@@ -64,7 +64,7 @@ Ext.define('cssLockedGrid.scroll.indicator.Bar', {
                 me.spacerElement.setStyle(names.spacerMargin, (
                     Math.min(scrollSize, maxScrollSize) - 1
                 ) + 'px');
-console.log(axis, scrollSize, maxScrollSize);
+//console.log(axis, scrollSize, maxScrollSize);
 //                console.log(me.spacerElement);
 
                 if (axis === 'x') {
@@ -75,12 +75,12 @@ console.log(axis, scrollSize, maxScrollSize);
                     if (scroller.getUserClientSize()) {
                         clientSize = scroller.getUserClientSize()['x'];
                         adjust = scrollElSize - clientSize;
-                        console.log('scrollsize is ', scrollSize);
-                        console.log('scrollElsize is ', scrollElSize);
-                        console.log('adjust is ', adjust);
-                        console.log('clientSize is ', clientSize);
+//                        console.log('scrollsize is ', scrollSize);
+//                        console.log('scrollElsize is ', scrollElSize);
+//                        console.log('adjust is ', adjust);
+//                        console.log('clientSize is ', clientSize);
                         scrollSize = scrollSize - adjust; // (219 + 210);
-                        console.log('adjusted scrollSize is ', scrollSize)
+//                        console.log('adjusted scrollSize is ', scrollSize)
                         me.spacerElement.setStyle(names.spacerMargin, (
                             Math.min(scrollSize, maxScrollSize) - 1
                         ) + 'px');

--- a/src/grid/lockable/Divider.js
+++ b/src/grid/lockable/Divider.js
@@ -29,17 +29,57 @@ Ext.define('Ext.grid.lockable.RegionDivider', {
         })
     },
 
+    /**
+     * @method
+     * Calculates divider height and top position as well as if the divider should be
+     * displayed or not based on right/left region content.
+     *
+     * TODO: ENSURE GRID PADDING/MARGIN/BORDERS are accounted for when computing divider position.
+     * NOTE: Positioning of RIGHT divider calculatins MAY be off by 1px to far to the right.... investigate
+     *       You can notice this when the z-index for the divider is removed.
+     */
     showDivider: function() {
         var me = this,
             grid = me.getGrid(),
-            scrollableMax = grid.getScrollable().getMaxPosition().x,
-            borderPadding = grid.el.getBorderPadding(),
-            centerRegionBox = grid.getCenterRegionBox(),
             region = me.getRegion(),
-            visible = !!grid.getRegionWidth(region) && !(region === 'right' && !scrollableMax);
+            height = grid.bodyElement.getSize().height,
+            scrollMax = grid.getScrollable().getMaxPosition().x,
+            regionWidth = grid.getRegionWidth(region),
+            visible = !!regionWidth && !(region === 'right' && !scrollMax);
+
+        if (visible) {
+            const dockedItems = grid.getDockedItems();
+            const gridBox = grid.el.getBox();
+            const borders = grid.el.getBorders();
+            const borderPadding = grid.el.getBorderPadding();
+            let x = 0, y = 0;
+
+            if (region === 'left') {
+                x = regionWidth + (borderPadding.beforeX - borders.beforeX);
+            }
+            else {
+                x = (gridBox.right - gridBox.left - borderPadding.afterX) - regionWidth;
+                x -= (borderPadding.afterX - borders.afterX);
+            }
+
+            dockedItems.forEach(item => {
+                switch (item.getDocked()) {
+                    case 'top':
+                        if (['headercontainer', 'container'].includes(item.xtype)) {
+                            height += item.getSize().height;
+                            break;
+                        }
+                        y += item.getSize().height;
+                        break;
+                    case 'bottom':
+                        // We may need to adjust for docked 'rows' (summmary, etc). For now, we do nothing
+                        // with bottom docked items.
+                }
+            });
+            me.setHeight(height);
+            me.setXY(x, y);
+        }
 
         me.setVisibility(visible);
-        me.setHeight(centerRegionBox.bodyHeight);
-        me.setXY(centerRegionBox[region], centerRegionBox.bodyTop);
     }
 });

--- a/src/grid/plugin/Lockable.js
+++ b/src/grid/plugin/Lockable.js
@@ -85,7 +85,7 @@ Ext.define('Ext.grid.plugin.Lockable', {
     setCmp: function (cmp) {
         this.cmp = cmp;
 
-        if (cmp && cmp.isGrid && !cmp.isLockedGrid) {
+        if (cmp && cmp.isGrid && !cmp.isCssLockedGrid) {
             this.decorate(cmp);
         } else {
             Ext.log.error('Lockable plugin can only be used included for Ext.grid.Grid based classes.');
@@ -100,7 +100,7 @@ Ext.define('Ext.grid.plugin.Lockable', {
             //
             Ext.override(target, {
                 // differentiate between lockable plugin and Ext.grid.locked.Grid
-                isLockedGrid: true,
+                isCssLockedGrid: true,
 
                 getRegions: function() {
                     return plugin.getRegions();
@@ -128,30 +128,24 @@ Ext.define('Ext.grid.plugin.Lockable', {
                 },
 
                 getCenterRegionBox: function () {
-                    var me = this,
-                        gridBox = me.el.getBox(),
-                        borders = me.el.getBorders(),
-                        borderPadding = me.el.getBorderPadding(),
-                        left = me.getRegionWidth('left') + (borderPadding.beforeX - borders.beforeX),
-                        right = (gridBox.right - gridBox.left - borderPadding.afterX) - me.getRegionWidth('right'),
+                    var grid = this,
+                        gridBox = grid.el.getBox(),
+                        borders = grid.el.getBorders(),
+                        borderPadding = grid.el.getBorderPadding(),
+                        left = grid.getRegionWidth('left') + (borderPadding.beforeX - borders.beforeX),
+                        right = (gridBox.right - gridBox.left - borderPadding.afterX) - grid.getRegionWidth('right'),
                         height = gridBox.height - (borderPadding.beforeY + borderPadding.afterY),
-                        titleHeight = me.getTitleBar() ? me.getTitleBar().getSize().height : 0;
-
-//console.log(borders);
-//console.log(borderPadding)
                         right = right - (borderPadding.afterX - borders.afterX);
 
+                    //console.log(borders);
+                    //console.log(borderPadding)
                     return {
                         x: left,
                         y: gridBox.y,
                         left: left,
                         right: right,
                         width: right - left,
-                        height: height,
-
-                        bodyTop: titleHeight + (borderPadding.beforeX - borders.beforeY),
-                        bodyHeight: height - titleHeight,
-                        bodyWidth: gridBox.width - (borderPadding.beforeX + borderPadding.afterX),
+                        height: height
                     };
                 },
 
@@ -260,6 +254,7 @@ Ext.define('Ext.grid.plugin.Lockable', {
                 use3d = true,
                 scroller = grid.getScrollable();
 
+                console.log('REFRESH REGIONS...')
             var offsets = grid.getRegionOffsets();
 //            console.log(scroller.getPosition())
             var lockedLeft = grid.el.query('.x-locked.x-locked-left');

--- a/src/grid/plugin/Lockable.scss
+++ b/src/grid/plugin/Lockable.scss
@@ -9,7 +9,7 @@
 .x-headercontainer .x-gridcolumn.x-locked,
 .x-grid-filterbar .x-locked,
 .x-gridcell.x-locked {
-    z-index: 10;
+    z-index: 10;  // Mask is z-index 10
 }
 
 .x-headercontainer .x-gridcolumn.x-locked,


### PR DESCRIPTION
- Moved all logic for divider positioning and height into Divider component
- renamed css grid identifying property from isLockedGrid to isCssLockedGrid (to conform to naming standard of this package)
- Add initial sorting code to address problem when columns are configured not in locked order. This caused issues with correctly (re)configuring grids
- 